### PR TITLE
Allow to use MiSTer bootstrap without the github API token

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ GOCMD=go
 GOBUILD=$(GOCMD) build
 GOCLEAN=$(GOCMD) clean
 BINARY_NAME=bootstrap
+CGO_ENABLED=0
 
 all:	clean build
 build: 

--- a/src/main.go
+++ b/src/main.go
@@ -8,7 +8,9 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -16,29 +18,44 @@ import (
 	"golang.org/x/oauth2"
 )
 
+const (
+	org            = "MiSTer-devel"
+	releasedirpath = "releases"
+)
+
+func getDefaultPath() string {
+	home := ""
+	if runtime.GOOS == "windows" {
+		home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+		if home == "" {
+			home = os.Getenv("USERPROFILE")
+		}
+
+	} else if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
+		home = "/tmp"
+	}
+	return path.Join(home, "mister")
+}
+
 func main() {
 	token := flag.String("t", "", "Github Personal API Token")
-	output := flag.String("o", "/tmp/mister", "Output Directory")
+	output := flag.String("o", getDefaultPath(), "Output Directory")
 
 	flag.Parse()
 
 	os.MkdirAll(*output, os.ModePerm)
 
-	if *token == "" {
-		fmt.Println("Github Personal API Token Required, use -t <API Token>")
-		os.Exit(-1)
-	}
-
-	org := "MiSTer-devel"
-	path := "releases"
-
 	ctx := context.Background()
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: *token},
-	)
-	tc := oauth2.NewClient(ctx, ts)
 
-	client := github.NewClient(tc)
+	client := github.NewClient(nil)
+
+	if *token != "" {
+		ts := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: *token},
+		)
+		tc := oauth2.NewClient(ctx, ts)
+		client = github.NewClient(tc)
+	}
 
 	opt := &github.RepositoryListByOrgOptions{
 		ListOptions: github.ListOptions{PerPage: 500},
@@ -53,7 +70,7 @@ func main() {
 	hasCoresTest := func(s string) bool { return strings.HasSuffix(s, ".rbf") }
 
 	for _, repo := range repos {
-		_, dir, _, err := client.Repositories.GetContents(ctx, org, *repo.Name, path, nil)
+		_, dir, _, err := client.Repositories.GetContents(ctx, org, *repo.Name, releasedirpath, nil)
 
 		if err != nil {
 			continue
@@ -72,7 +89,7 @@ func main() {
 		latest := cores[len(cores)-1]
 
 		if _, err := os.Stat(fmt.Sprintf("%s/%s", *output, *latest.Name)); os.IsNotExist(err) {
-			log.Printf("Downloadin %s core...\n", *latest.Name)
+			log.Printf("Downloading %s core...\n", *latest.Name)
 			err := DownloadCore(fmt.Sprintf("%s/%s", *output, *latest.Name), *latest.DownloadURL)
 
 			if err != nil {


### PR DESCRIPTION
The patch allows using MiSTer bootstrap without the GitHub API token. bootstrapping rdf files should work on Linux, Darwin and Windows platforms. 